### PR TITLE
Rename the policy to `expect-no-linked-resources`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# `expect-no-embedded-resources` explainer
+# `expect-no-linked-resources` explainer
 
-The `expect-no-embedded-resources` [configuration point](https://wicg.github.io/document-policy#configuration-point) in [Document Policy](https://wicg.github.io/document-policy/) allows a document to hint to the user agent to better optimize its loading sequence, such as not using the default speculative parsing behavior.
+The `expect-no-linked-resources` [configuration point](https://wicg.github.io/document-policy#configuration-point) in [Document Policy](https://wicg.github.io/document-policy/) allows a document to hint to the user agent to better optimize its loading sequence, such as not using the default speculative parsing behavior.
 
 ## Participate
-- https://github.com/explainers-by-googlers/expect-no-embedded-resources/issues
+- https://github.com/explainers-by-googlers/expect-no-linked-resources/issues
 
 ## Table of Contents
 
@@ -11,7 +11,7 @@ The `expect-no-embedded-resources` [configuration point](https://wicg.github.io/
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [`expect-no-embedded-resources` explainer](#expect-no-embedded-resources-explainer)
+- [`expect-no-linked-resources` explainer](#expect-no-linked-resources-explainer)
   - [Participate](#participate)
   - [Table of Contents](#table-of-contents)
   - [Introduction](#introduction)
@@ -35,18 +35,18 @@ User Agents have implemented [speculative parsing of HTML](https://html.spec.wha
  * Pages that do not have any resources declared in the HTML.
  * Large HTML pages with minimal or no resource loads that could explicitly control preloading resources via other preload mechanisms available.
 
-This proposal introduces a [configuration point](https://wicg.github.io/document-policy#configuration-point) in [Document Policy](https://wicg.github.io/document-policy/) `expect-no-embedded-resources` to explicitly state to the User Agent that it may choose to optimize out the time spent in such sub resource determination.
+This proposal introduces a [configuration point](https://wicg.github.io/document-policy#configuration-point) in [Document Policy](https://wicg.github.io/document-policy/) `expect-no-linked-resources` to explicitly state to the User Agent that it may choose to optimize out the time spent in such sub resource determination.
 
 ## Example
 
-A document can hint to the user agent that it may assume no resources are embedded within the response html markup, by using the `expect-no-embedded-resources` [configuration point](https://wicg.github.io/document-policy#configuration-point) in [Document Policy](https://wicg.github.io/document-policy/).
+A document can hint to the user agent that it may assume no resources are embedded within the response html markup, by using the `expect-no-linked-resources` [configuration point](https://wicg.github.io/document-policy#configuration-point) in [Document Policy](https://wicg.github.io/document-policy/).
 
 
 ```http
 HTTP/1.1 200 OK
 Content-Type: text/html
 ...
-Document-Policy: expect-no-embedded-resources
+Document-Policy: expect-no-linked-resources
 ...
 ```
 
@@ -79,7 +79,7 @@ The specification for this feature in itself consists of two parts.
 
 One part is header parsing, which relies on the [configuration point](https://wicg.github.io/document-policy#configuration-point) defined in [Document Policy](https://wicg.github.io/document-policy/) and the associated infrastructure to read the configuration point. The other is altering behavior of the [active HTML speculative parser](https://html.spec.whatwg.org/multipage/parsing.html#active-speculative-html-parser), which would be done by modifying the HTML Standard's [Speculative HTML parsing](https://html.spec.whatwg.org/multipage/parsing.html#speculative-html-parsing).
 
-Please see the associated [spec proposal](https://explainers-by-googlers.github.io/expect-no-embedded-resources) for more information.
+Please see the associated [spec proposal](https://explainers-by-googlers.github.io/expect-no-linked-resources) for more information.
 
 ## Considered alternatives
 

--- a/index.bs
+++ b/index.bs
@@ -1,12 +1,12 @@
 <pre class='metadata'>
-Title: expect-no-embedded-resources
-Shortname: expect-no-embedded-resources
+Title: expect-no-linked-resources
+Shortname: expect-no-linked-resources
 Level: None
 Status: w3c/UD
-Repository: explainers-by-googlers/expect-no-embedded-resources
-URL: https://explainers-by-googlers.github.io/expect-no-embedded-resources
+Repository: explainers-by-googlers/expect-no-linked-resources
+URL: https://explainers-by-googlers.github.io/expect-no-linked-resources
 Editor: Alex N. Jose, Google LLC https://google.com, alexnj@google.com
-Abstract: The `expect-no-embedded-resources` <a href="https://wicg.github.io/document-policy#configuration-point">configuration point</a> in [[!document-policy|Document Policy]] allows a developer to hint the user agent to optimize loading behavior assuming the HTML response has no resources embedded within its markup.
+Abstract: The `expect-no-linked-resources` <a href="https://wicg.github.io/document-policy#configuration-point">configuration point</a> in [[!document-policy|Document Policy]] allows a developer to hint the user agent to optimize loading behavior assuming the HTML response has no resources embedded within its markup.
 Markup Shorthands: markdown yes, css no
 Complain About: accidental-2119 yes, missing-example-ids yes
 Assume Explicit For: yes
@@ -19,21 +19,21 @@ Include Can I Use Panels: yes
 
 # Introduction # {#introduction}
 
-A document can hint the user agent that its HTML markup has no resources embedded to allow the user agent to better optimize the loading sequence, such as not using the default speculative parsing behavior, by using the `expect-no-embedded-resources` <a href="https://wicg.github.io/document-policy#configuration-point">configuration point</a> in [[!document-policy|Document Policy]].
+A document can hint the user agent that its HTML markup has no resources embedded to allow the user agent to better optimize the loading sequence, such as not using the default speculative parsing behavior, by using the `expect-no-linked-resources` <a href="https://wicg.github.io/document-policy#configuration-point">configuration point</a> in [[!document-policy|Document Policy]].
 
 The consequence of using this header may be that a user agent would skip certain optimizations such as the Document's [active speculative HTML parser](https://html.spec.whatwg.org/multipage/parsing.html#active-speculative-html-parser) that attempts to find resources embedded in HTML.
 
 # Document-Policy Integration # {#document-policy-integration}
 
 This specification defines a <a href="https://wicg.github.io/document-policy#configuration-point">configuration point</a>
-in [[!document-policy|Document Policy]] with name "expect-no-embedded-resources". Its
+in [[!document-policy|Document Policy]] with name "expect-no-linked-resources". Its
 <a href="https://wicg.github.io/document-policy#configuration-point-type">type</a> is `boolean`
 with <a href="https://wicg.github.io/document-policy#configuration-point-default-value">default value</a>
 `false`.
 
 <div class='example'>
   ```
-  Document-Policy: expect-no-embedded-resources
+  Document-Policy: expect-no-linked-resources
   ```
 </div>
 
@@ -42,4 +42,4 @@ with <a href="https://wicg.github.io/document-policy#configuration-point-default
 
 1. Insert a step after step 1 of [start the speculative HTML parser](https://html.spec.whatwg.org/#start-the-speculative-html-parser) as following:
 
-    1. <a href="https://wicg.github.io/document-policy#algo-get-policy-value">Get the document policy value</a> of the "expect-no-embedded-resources" <a href="https://wicg.github.io/document-policy#configuration-point">configuration point</a> for the [=/Document=]. If the result is `true`, then the user agent may return.
+    1. <a href="https://wicg.github.io/document-policy#algo-get-policy-value">Get the document policy value</a> of the "expect-no-linked-resources" <a href="https://wicg.github.io/document-policy#configuration-point">configuration point</a> for the [=/Document=]. If the result is `true`, then the user agent may return.


### PR DESCRIPTION
Fixes #3. 

Renames the policy to `expect-no-linked-resources` to avoid potential confusion with inlined resources.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/alexnj/expect-no-embedded-resources/pull/4.html" title="Last updated on Sep 9, 2024, 1:19 PM UTC (6721cdb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/explainers-by-googlers/expect-no-embedded-resources/4/93733d2...alexnj:6721cdb.html" title="Last updated on Sep 9, 2024, 1:19 PM UTC (6721cdb)">Diff</a>